### PR TITLE
Python requirements file that fixes the ValueError

### DIFF
--- a/lstm/requirements.txt
+++ b/lstm/requirements.txt
@@ -1,0 +1,10 @@
+h5py==2.6.0
+Keras==1.0.3
+numpy==1.11.1
+pycosat==0.6.1
+pycrypto==2.6.1
+PyYAML==3.11
+requests==2.9.1
+scipy==0.17.1
+six==1.10.0
+Theano==0.8.2


### PR DESCRIPTION
If you get the sum(pvals[:-1]) > 1.0 error when running outside Docker installing these requirements with:

`sudo pip3 install -r requirements.txt --ignore-installed`

fixes the problem
